### PR TITLE
MAINT: updated Cargo files: no refs to teaclave

### DIFF
--- a/enclave/safetrace/Makefile
+++ b/enclave/safetrace/Makefile
@@ -21,8 +21,6 @@
 SGX_SDK ?= $(HOME)/.sgxsdk/sgxsdk
 
 # The path to the incubator-teaclave-sgx-sdk code.
-# SGX_SDK_RUST ?= ../incubator-teaclave-sgx-sdk/
-
 SGX_SDK_RUST ?= $(HOME)/sgx
 
 

--- a/enclave/safetrace/app/Cargo.toml
+++ b/enclave/safetrace/app/Cargo.toml
@@ -23,8 +23,3 @@ rmp-serde = "0.14.0"
 rustc-hex = "1.0.0"
 lazy_static = "1.3.0"
 log = "0.4.6"
-
-
-[patch.'https://github.com/apache/teaclave-sgx-sdk.git']
-sgx_types = { path = "../../incubator-teaclave-sgx-sdk/sgx_types" }
-sgx_urts = { path = "../../incubator-teaclave-sgx-sdk/sgx_urts" }

--- a/enclave/safetrace/enclave/Cargo.toml
+++ b/enclave/safetrace/enclave/Cargo.toml
@@ -18,12 +18,9 @@ enigma-tools-t = { git = "https://github.com/enigmampc/enigma-core.git", branch=
 enigma-tools-m = { git = "https://github.com/enigmampc/enigma-core.git", branch="develop", default-features = false, features = ["sgx"] }
 enigma-runtime-t = { git = "https://github.com/enigmampc/enigma-core.git", branch="develop" }
 
-# rustc-hex = { version = "2.0", default-features = false }
 serde = { git = "https://github.com/mesalock-linux/serde-sgx.git", rev = "sgx_1.0.9", features=["serde_derive"] }
 serde_json = { git = "https://github.com/enigmampc/serde-json-sgx.git", rev = "1.0.39-sgx-1.0.9" }
 rmp-serde = {git = "https://github.com/enigmampc/msgpack-rust.git", rev =  "0.14.0-sgx-1.0.9" }
-
-# serde_cbor = { git = "https://github.com/mesalock-linux/cbor-sgx.git", rev = "sgx_1.0.9", default-features = false, features=["mesalock_sgx"] }
 lazy_static = {version = "1.4.0", features = ["spin_no_std"] }
 
 sgx_types = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.9" }

--- a/enclave/safetrace/enclave/src/data.rs
+++ b/enclave/safetrace/enclave/src/data.rs
@@ -22,7 +22,7 @@ pub const DATAFILE: &str = "data.sealed";
 pub const TOVERLAP: i32 = 300;             // 5min * 60s minimum overlap
 pub const DISTANCE: f64 = 10.0;            // in meters
 pub const EARTH_RADIUS: f64 = 6371000.0;   // in meters
-pub const SEAL_LOG_SIZE: usize = 4096; // Maximum data can seal in bytes -> match 
+pub const SEAL_LOG_SIZE: usize = 4096;     // Maximum data can seal in bytes -> smaller than "HeapMaxSize" in Enclave.config.xml
 
 
 pub enum Error {


### PR DESCRIPTION
Follow up work from #44, removing references to Apache/teaclave and other minor maintenance updates.