### PR TITLE
BLD: better error handling, preventing segfault

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -43,7 +43,40 @@ Submits new personal data from the user (identified by its `userId`) providing a
 
 **Returns**
 
-* `result` (Boolean) - `true` if the operation was successful, `false` otherwise
+* `status` (Integer) - `0` if the operation was successful, other values otherwise
+
+    **Successsful Operation**
+
+    ```json
+    {
+	  "jsonrpc": "2.0",
+	  "id": 1,
+	  "result": {
+	  	"id": "dd5ee176c4",
+	  	"type": "AddPersonalData",
+	  	"addPersonalData": {
+	  	  "status": 0
+	  	}
+	  }
+	}
+	```
+
+	**Failed Operation**
+
+    ```json
+    {
+	  "jsonrpc": "2.0",
+	  "id": 1,
+	  "result": {
+	  	"id": "3254abe86c",
+	  	"type": "AddPersonalData",
+	  	"addPersonalData": {
+	  	  "status": -1
+	  	}
+	  }
+	}
+	```
+
 
 ## findMatch
 
@@ -55,9 +88,35 @@ Queries whether there is a match both in location and time between the user (ide
 
 **Returns**
 
-* `result` (Boolean) - `true` if at least one match was found, `false` otherwise
-* `matches` (Array) - if a match was found, this field will be populated with an array of `lat`, `lng` and `timestamp` where a match was found.
+* `status` (Integer) - `0` if the operation was successful, other values otherwise
+* `matches` (Array) - if a match was found, this field will be populated with an array of `lat`, `lng` and `timestamp` where a match was found. If no match was found, this will return an empty array. This field comes encrypted, and needs to be decrypted to obtain the array.
 
+    **Successsful Operation**
+    
+    ```json
+    { 
+        "id": "4078a17e30",
+        "type": "FindMatch",
+        "findMatch":
+        {
+	    "status": 0,
+            "encryptedOutput": "25b2ec3c7b1ed1fdd0bf2fcc517b12af815fb1b161f3949f5fe0cb60c17e"
+	}
+    }
+    ```
+
+    **Failed Operation**
+    
+    ```json
+    { 
+        "id": "da7d3d68ff",
+        "type": "FindMatch",
+        "findMatch":
+        {
+	    "status": -1,
+	}
+    }
+    ````
 
 # Data Specification
 

--- a/client/README.md
+++ b/client/README.md
@@ -135,6 +135,11 @@ to run the method `newTaskEncryptionKey` everytime to be able to derive that key
 curl -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id":1, "method":"findMatch", "params": {"encryptedUserId":"15806c56ed8fb37a9a45c8c3efa227a98a406c5787bf3ff90f0c89fde8ad3d6fdd", "userPubKey": "cc955077ff7aeb67e544bb0dfad0a5ac1d3117f4115c528d38da9c2337cb033ec08f1d12a580d2ccfed02144e70d961c72e28e92ef48b9056c08137918c5ab2d"}}' https://safetrace.enigma.co
 ```
 
+*NOTE: Analogously to the previous method, the input and output from this method are encrypted, which you can encrypt and
+decrypt with the key derived through Diffie-Hellman. Again, the command and output included here are for reference 
+purposes, but you will not be able to reproduce verbatim. Instead, you have to run `newTaskEncryptionKey` and use that
+for encryption and decryption. Each key can only be used once, so running any command like this through `curl` reusing parameters from a previous operation like the ones presented here, results in a failed operation.*
+
 * Failed Response
 
 ```json
@@ -150,9 +155,3 @@ curl -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id":1, "method"
   }
 }
 ```
-
-*NOTE: Analogously to the previous method, the input and output from this method are encrypted, which you can encrypt and
-decrypt with the key derived through Diffie-Hellman. Again, the command and output included here are for reference 
-purposes, but you will not be able to reproduce verbatim. Instead, you have to run `newTaskEncryptionKey` and use that
-for encryption and decryption. Each key can only be used once, so running any command like this through `curl` reusing parameters from a previous operation like the ones presented here, results in a failed operation.*
-

--- a/client/README.md
+++ b/client/README.md
@@ -109,9 +109,9 @@ curl -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id":1, "method"
 ```
 
 *NOTE: The parameters `encryptedUserId` and `encryptedData` are encrypted with an ephemeral Diffie-Hellman key, so you need
-to run the method `newTaskEncryptionKey` everytime to be able to derive that key, and use it to encrypt these parameters. This also means that the encrypted values will change every time.*
+to run the method `newTaskEncryptionKey` everytime to be able to derive that key, and use it to encrypt these parameters. Each key can only be used once, so running any command like this through `curl` reusing parameters from a previous operation like the ones presented here, results in a failed operation.*
 
-* Response
+* Failed Response
 
 ```json
 {
@@ -121,7 +121,7 @@ to run the method `newTaskEncryptionKey` everytime to be able to derive that key
     "id":"eb2f102370",
     "type":"AddPersonalData",
     "addPersonalData": {
-      "status":0
+      "status": -1
     }
   }
 }
@@ -135,7 +135,7 @@ to run the method `newTaskEncryptionKey` everytime to be able to derive that key
 curl -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id":1, "method":"findMatch", "params": {"encryptedUserId":"15806c56ed8fb37a9a45c8c3efa227a98a406c5787bf3ff90f0c89fde8ad3d6fdd", "userPubKey": "cc955077ff7aeb67e544bb0dfad0a5ac1d3117f4115c528d38da9c2337cb033ec08f1d12a580d2ccfed02144e70d961c72e28e92ef48b9056c08137918c5ab2d"}}' https://safetrace.enigma.co
 ```
 
-* Response
+* Failed Response
 
 ```json
 { 
@@ -145,11 +145,7 @@ curl -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id":1, "method"
     "id": "d23d723a6a",
     "type": "FindMatch",
     "findMatch": { 
-      "status": 0,
-      "encryptedOutput": "45c90f568a5bb096fc39ae8429c3e05cd29f40c30c0f89e8c0395cf431f5c2934d
-      232cff4eb3c27b18e9704790e65b0bdecdcd02d6e8b5b668991d3e53b804c23b24c7f5d9e5d1a2c322036a
-      3068991ddc0ebd7a56ddd1b90a7d857c790844f5233b22aad906bea938c77d24882b1043d2e84b2c8d959d
-      d0"
+      "status": -1
     } 
   }
 }
@@ -158,5 +154,5 @@ curl -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id":1, "method"
 *NOTE: Analogously to the previous method, the input and output from this method are encrypted, which you can encrypt and
 decrypt with the key derived through Diffie-Hellman. Again, the command and output included here are for reference 
 purposes, but you will not be able to reproduce verbatim. Instead, you have to run `newTaskEncryptionKey` and use that
-for encryption and decryption.*
+for encryption and decryption. Each key can only be used once, so running any command like this through `curl` reusing parameters from a previous operation like the ones presented here, results in a failed operation.*
 

--- a/enclave/safetrace/app/src/networking/ipc_listener.rs
+++ b/enclave/safetrace/app/src/networking/ipc_listener.rs
@@ -156,7 +156,12 @@ pub(self) mod handling {
                                          encrypted_data.len(),
                                          &user_pub_key) };
 
-        let result = IpcResults::AddPersonalData { status: Status::Passed };
+        let result;
+        if(ret == sgx_status_t::SGX_SUCCESS) {
+            result = IpcResults::AddPersonalData { status: Status::Passed };
+        } else {
+            result = IpcResults::AddPersonalData { status: Status::Failed };
+        }
         Ok(IpcResponse::AddPersonalData { result })
     }
 
@@ -184,7 +189,12 @@ pub(self) mod handling {
         let box_ptr = serialized_ptr as *mut Box<[u8]>;
         let part = unsafe { Box::from_raw(box_ptr) };
 
-        let result = IpcResults::FindMatch { status: Status::Passed, encryptedOutput: part.to_hex()};
+        let result;
+        if(ret == sgx_status_t::SGX_SUCCESS) {
+            result = IpcResults::FindMatch { status: Status::Passed, encryptedOutput: part.to_hex()};
+        } else {
+            result = IpcResults::FindMatch { status: Status::Failed, encryptedOutput: "".to_string() };
+        }
         Ok(IpcResponse::FindMatch { result })
     }
 

--- a/enclave/safetrace/app/src/networking/messages.rs
+++ b/enclave/safetrace/app/src/networking/messages.rs
@@ -54,7 +54,7 @@ pub enum IpcResults {
     #[serde(rename = "result")]
     DHKey { taskPubKey: String, sig: String },
     AddPersonalData { status: Status },
-    FindMatch { status: Status, encryptedOutput: String },
+    FindMatch { status: Status, #[serde(skip_serializing_if = "String::is_empty")] encryptedOutput: String },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/enclave/safetrace/enclave/src/lib.rs
+++ b/enclave/safetrace/enclave/src/lib.rs
@@ -167,6 +167,14 @@ pub unsafe extern "C" fn ecall_find_match(
     userPubKey: &[u8; 64],
     serialized_ptr: *mut u64) -> EnclaveReturn {
 
+    // Initialize the pointer, in case we error out, it points somewhere,
+    // otherwise we get a segmentation fault when we throw an error
+    let empty = [0u8];
+    *serialized_ptr = match ocalls_t::save_to_untrusted_memory(&empty) {
+        Ok(ptr) => ptr,
+        Err(e) => return e.into(),
+    };
+
     let encryptedUserId = slice::from_raw_parts(encryptedUserId, encryptedUserId_len);
 
     let io_key;


### PR DESCRIPTION
Slight improvement in propagating errors from inside the enclave to the untrusted, which gets back to the user via the JSON RPC server.

If the Diffie-Hellman key is not found (which is ephemeral and can only be used once), the server will return a `"status": -1`. 

Up until now, the `addPersonalData` endpoint was failing silently, giving the user the false impression that the operation succeeded, while the `findMatch` endpoint was causing a *segmentation fault* that crashed the enclave, and resulted in a `502 - Bad Gateway` error back to the user. 

Updated API and client READMEs accordingly.