### PR TITLE
BLD: live address for safetrace server

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -7,7 +7,7 @@ const web3utils = require('web3-utils');
 const data = require('./data.js');
 
 
-const JSON_RPC_Server='http://localhost:8080';
+const JSON_RPC_Server='https://safetrace.enigma.co';
 
 const callServer = function(request, callback) {
   let config = {


### PR DESCRIPTION
Updates the RPC server address that the client uses in the example code, from `localhost` used in the initial testing to the live address where it lives now.