### PR TITLE
Fix link to safetrace's Makefile

### DIFF
--- a/enclave/INSTALL.md
+++ b/enclave/INSTALL.md
@@ -18,7 +18,7 @@ First, make sure you have Rust installed: https://www.rust-lang.org/tools/instal
 
     ```bash
     cargo install bindgen
-    ```  
+    ```
 
 Then you can use this script (or run the commands one-by-one), which was tested on Ubuntu 18.04 with SGX driver/sdk version 2.6:
 
@@ -150,9 +150,9 @@ sudo $HOME/.sgxsdk/sgx_linux_x64_driver_*.bin
 
    ```
 
-   *Note: This setup assumes that you run the above command in your $HOME folder, and thus you have the above repo cloned at $HOME/sgx. If you clone it anywhere else, update Line 26 of the [Makefile](enclave/safetrace/Makefile) accordingly:*
+   *Note: This setup assumes that you run the above command in your $HOME folder, and thus you have the above repo cloned at $HOME/sgx. If you clone it anywhere else, update Line 24 of the [Makefile](safetrace/Makefile) accordingly:*
 
-   ```bash
+   ```make
    SGX_SDK_RUST ?= $(HOME)/sgx
    ```
 


### PR DESCRIPTION
The line number pointing to the line that may need to be changed in the Makefile is also changed as it is now 24, as opposed to 26.

Some small improvements were also done "along the way". If preferred, I can submit these in a separate pull request. Those improvements are summarized in the commit message and are:

* Remove extra whitespace.
* Use `make` as the language to highlight the code snippet from the `Makefile`.
* Remove the newline character at the end of the last line.

The newline character at the end of the file was automatically removed by editor. If somehow it needs to stay, then I guess I need to figure out how to configure my text editor for this project ...